### PR TITLE
Readme and pom.xml updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add this into your `pom.xml` to start using the Swagger UI.
   </repository>
 </repositories>
 ```
-  
+
 ## Public Domain
 This repository constitutes a work of the United States Government and is not
 subject to domestic copyright protection under 17 USC § 105. This repository is in
@@ -31,22 +31,15 @@ submitting a pull request you are agreeing to comply with this waiver of
 copyright interest.
 
 ## License
-The repository utilizes code licensed under the terms of the Apache Software
-License and therefore is licensed under ASL v2 or later.
+This repository utilizes code licensed under the terms of the Apache Software License and therefore is licensed under ASL v2 or later.
 
-This source code in this repository is free: you can redistribute it and/or modify it under
-the terms of the Apache Software License version 2, or (at your option) any
-later version.
+The source code in this repository is free: you can redistribute it and/or modify it under the terms of the Apache Software License version 2, or (at your option) any later version.
 
-This soruce code in this repository is distributed in the hope that it will be useful, but WITHOUT ANY
-WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE. See the Apache Software License for more details.
+The source code in this repository is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Apache Software License for more details.
 
-You should have received a copy of the Apache Software License along with this
-program. If not, see http://www.apache.org/licenses/LICENSE-2.0.html
+You should have received a copy of the Apache Software License along with this program. If not, see https://www.apache.org/licenses/LICENSE-2.0.html.
 
 The source code forked from other open source projects will inherit its license.
-
 
 ## Privacy
 This repository contains only non-sensitive, publicly available data and

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,27 @@
 		<developerConnection>scm:git:git@github.com:CDCgov/springfox-swagger-ui.git</developerConnection>
 	</scm>
 
+	<developers>
+		<developer>
+			<id>bchevallereau</id>
+			<name>Ben Chevallereau</name>
+			<email>benjamin.chevallereau@gmail.com</email>
+			<url>https://www.linkedin.com/in/bchevallereau/</url>
+			<roles>
+				<role>developer</role>
+			</roles>
+		</developer>
+		<developer>
+			<id>drewry</id>
+			<name>Drew Morris</name>
+			<email>dhmorris@gmail.com</email>
+			<url>https://github.com/drewry</url>
+			<roles>
+				<role>developer</role>
+			</roles>
+		</developer>
+	</developers>
+
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Added a `<developers>` entry after consultations with the XLR team to credit those who designed the library and then wrote the code to implement it. Updated a misspelling of 'source' in `README.md` that originated from the SDP legal template.